### PR TITLE
Update default SML URLs for Peppol SML insourcing (fixes #28)

### DIFF
--- a/peppol-smp/src/main/java/org/holodeckb2b/bdxr/smp/server/services/peppol/SMLClient.java
+++ b/peppol-smp/src/main/java/org/holodeckb2b/bdxr/smp/server/services/peppol/SMLClient.java
@@ -88,12 +88,12 @@ public class SMLClient implements SMLIntegrationService {
 
 	@Value("${peppol.sml.prod.name:Peppol Production SML}")
 	protected String prodName;
-	@Value("${peppol.sml.prod.url:https://edelivery.tech.ec.europa.eu/edelivery-sml}")
+	@Value("${peppol.sml.prod.url:https://api.sml.prod.tech.peppol.org/edelivery-sml}")
 	protected String prodURL;
 
 	@Value("${peppol.sml.acc.name:Peppol Acceptance SML (SMK)}")
 	protected String testName;
-	@Value("${peppol.sml.acc.url:https://acc.edelivery.tech.ec.europa.eu/edelivery-sml}")
+	@Value("${peppol.sml.acc.url:https://api.sml.test.tech.peppol.org/edelivery-sml}")
 	protected String testURL;
 
 	@Value("${peppol.sml.ssl.verifyhostname:true}")


### PR DESCRIPTION
## Summary

- Update default production SML URL from `https://edelivery.tech.ec.europa.eu/edelivery-sml` to `https://api.sml.prod.tech.peppol.org/edelivery-sml`
- Update default acceptance SML URL from `https://acc.edelivery.tech.ec.europa.eu/edelivery-sml` to `https://api.sml.test.tech.peppol.org/edelivery-sml`

OpenPeppol is insourcing the SML from the EC eDelivery infrastructure to its own Peppol-hosted service. The SMP registration migration deadline is 31 May 2026. Existing deployments that override the URLs via `peppol.sml.prod.url` / `peppol.sml.acc.url` properties are unaffected.